### PR TITLE
Bug fix : multiple reload app on Android

### DIFF
--- a/XamarinForms.LocationService.Android/Services/AndroidLocationService.cs
+++ b/XamarinForms.LocationService.Android/Services/AndroidLocationService.cs
@@ -13,6 +13,7 @@ namespace XamarinForms.LocationService.Droid.Services
     [Service]
     public class AndroidLocationService : Service
     {
+		private Location locShared;
 		CancellationTokenSource _cts;
 		public const int SERVICE_RUNNING_NOTIFICATION_ID = 10000;
 
@@ -23,6 +24,7 @@ namespace XamarinForms.LocationService.Droid.Services
 
 		public override StartCommandResult OnStartCommand(Intent intent, StartCommandFlags flags, int startId)
 		{
+			bool isAlreadyStart;
 			_cts = new CancellationTokenSource();
 
 			Notification notif = DependencyService.Get<INotification>().ReturnNotif();
@@ -31,8 +33,16 @@ namespace XamarinForms.LocationService.Droid.Services
 			Task.Run(() => {
 				try
 				{
-					var locShared = new Location();
-					locShared.Run(_cts.Token).Wait();
+					locShared = new Location();
+					isAlreadyStart = locShared.getRunningStateLocationService();
+					if (isAlreadyStart)
+					{
+					}
+					else
+					{
+						locShared.setRunningStateLocationService(true);
+						locShared.Run(_cts.Token).Wait();
+					}
 				}
 				catch (OperationCanceledException)
 				{
@@ -59,7 +69,7 @@ namespace XamarinForms.LocationService.Droid.Services
 				_cts.Token.ThrowIfCancellationRequested();
 				_cts.Cancel();
 			}
-
+			locShared.setRunningStateLocationService(false);
 			base.OnDestroy();
 		}
 	}

--- a/XamarinForms.LocationService.Android/XamarinForms.LocationService.Android.csproj
+++ b/XamarinForms.LocationService.Android/XamarinForms.LocationService.Android.csproj
@@ -100,4 +100,9 @@
     <AndroidResource Include="Resources\drawable\location.png" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties TriggeredFromHotReload="False" />
+    </VisualStudio>
+  </ProjectExtensions>
 </Project>

--- a/XamarinForms.LocationService/Services/Location.cs
+++ b/XamarinForms.LocationService/Services/Location.cs
@@ -9,17 +9,41 @@ namespace XamarinForms.LocationService.Services
 {
     public class Location
     {
-        readonly bool stopping = false;
 
 		public Location()
 		{
 		}
 
+		public void setRunningStateLocationService(bool isRunning)
+		{
+			if (isRunning)
+			{
+				Application.Current.Properties["locationServiceIsRunning"] = true;
+			}
+			else
+			{
+				Application.Current.Properties["locationServiceIsRunning"] = false;
+			}
+		}
+		public bool getRunningStateLocationService()
+		{
+			bool locationServiceIsRunning;
+			if (Application.Current.Properties.ContainsKey("locationServiceIsRunning"))
+			{
+				locationServiceIsRunning = Convert.ToBoolean(Application.Current.Properties["locationServiceIsRunning"]);
+			}
+			else
+			{
+				locationServiceIsRunning = false;
+			}
+			return locationServiceIsRunning;
+		}
+
 		public async Task Run(CancellationToken token)
 		{
 			await Task.Run(async () => {
-
-				while (!stopping)
+				System.Diagnostics.Debug.WriteLine(getRunningStateLocationService());
+				while (getRunningStateLocationService())
 				{
 					token.ThrowIfCancellationRequested();
 					try
@@ -51,6 +75,7 @@ namespace XamarinForms.LocationService.Services
 						});
 					}
 				}
+				return;
 			}, token);
 		}
 	}


### PR DESCRIPTION
Location.cs:
- Replace the value "stopping" by a value "isRunning" and store this value in the properties dictionnary (to save it trought the closing app).
- Create a GET and a SET function for this value

AndroidLocationService.cs:
- Location.locShared.Run(_cts.Token).Wait() only if no thread is already launch (only if the GET function return false).
- SET the value "isRunning" before the thread is running or end